### PR TITLE
Remove UGFX startup logo

### DIFF
--- a/stmhal/gfxconf.h
+++ b/stmhal/gfxconf.h
@@ -141,7 +141,7 @@
 #define GDISP_DEFAULT_ORIENTATION                    GDISP_ROTATE_LANDSCAPE    // If not defined the native hardware orientation is used.
 #define GDISP_LINEBUF_SIZE                           128
 #define GDISP_STARTUP_COLOR                          Black
-#define GDISP_NEED_STARTUP_LOGO                      TRUE
+#define GDISP_NEED_STARTUP_LOGO                      FALSE
 
 #define GDISP_TOTAL_DISPLAYS                         1
 


### PR DESCRIPTION
I'm all for giving proper attribution, but 1sec during every startup is getting a bit too much ;)
