### PR TITLE
List: make parent a kwarg, default up/down input

### DIFF
--- a/stmhal/ugfx_widgets.c
+++ b/stmhal/ugfx_widgets.c
@@ -56,7 +56,7 @@
 
 typedef struct _ugfx_button_t {
     mp_obj_base_t base;
-	
+
 	GHandle ghButton;
 
 } ugfx_button_obj_t;
@@ -69,21 +69,21 @@ STATIC mp_obj_t ugfx_button_make_new(const mp_obj_type_t *type, mp_uint_t n_args
     // check arguments
     mp_arg_check_num(n_args, n_kw, 5, 6, false);
 
-	
+
     const char *text = mp_obj_str_get_str(args[4]);
 	int x = mp_obj_get_int(args[0]);
 	int y = mp_obj_get_int(args[1]);
 	int a = mp_obj_get_int(args[2]);
 	int b = mp_obj_get_int(args[3]);
-	
+
 	GHandle parent = NULL;
 
-	
+
     // create button object
     ugfx_button_obj_t *btn = m_new_obj(ugfx_button_obj_t);
     btn->base.type = &ugfx_button_type;
-	
-	
+
+
 	//setup button options
 	GWidgetInit	wi;
 
@@ -91,13 +91,13 @@ STATIC mp_obj_t ugfx_button_make_new(const mp_obj_type_t *type, mp_uint_t n_args
 	gwinWidgetClearInit(&wi);
 	wi.g.show = TRUE;
 
-	// Apply the button parameters	
+	// Apply the button parameters
 	wi.g.width = a;
 	wi.g.height = b;
 	wi.g.y = y;
-	wi.g.x = x;	
+	wi.g.x = x;
 	wi.text = text;
-	
+
 	if (n_args > 5){
 		ugfx_container_obj_t *container = args[5];
 
@@ -107,7 +107,7 @@ STATIC mp_obj_t ugfx_button_make_new(const mp_obj_type_t *type, mp_uint_t n_args
 		}
 	}
 	wi.g.parent = parent;
-	
+
 	// Create the actual button
 	btn->ghButton = gwinButtonCreate(NULL, &wi);
 
@@ -120,9 +120,9 @@ STATIC mp_obj_t ugfx_button_make_new(const mp_obj_type_t *type, mp_uint_t n_args
 /// frees up all resources
 STATIC mp_obj_t ugfx_button_destroy(mp_obj_t self_in) {
     ugfx_button_obj_t *self = self_in;
-    
+
 	gwinDestroy(self->ghButton);
-	
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_button_destroy_obj, ugfx_button_destroy);
@@ -132,11 +132,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_button_destroy_obj, ugfx_button_destroy);
 ///
 STATIC mp_obj_t ugfx_button_attach_input(mp_obj_t self_in, mp_obj_t input) {
     ugfx_button_obj_t *self = self_in;
-	
+
 	int i = mp_obj_get_int(input);
-	
+
 	gwinAttachToggle(self->ghButton,0,i);
-	
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_button_attach_input_obj, ugfx_button_attach_input);
@@ -178,33 +178,36 @@ const mp_obj_type_t ugfx_button_type = {
 
 typedef struct _ugfx_list_t {
     mp_obj_base_t base;
-	
+
 	GHandle ghList;
 
 } ugfx_list_obj_t;
 
-/// \classmethod \constructor(x, y, a, b, {parent})
+/// \classmethod \constructor(x, y, a, b, *, parent=None, up=ugfx.JOY_UP, down=ugfx.JOY_DOWN)
 ///
 /// Construct an List object.
 /// Will take the style from the parent, if the parents style is set. Otherwise uses default style
+
+STATIC const mp_arg_t ugfx_list_make_new_args[] = {
+    { MP_QSTR_x, MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0} },
+    { MP_QSTR_y, MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0} },
+    { MP_QSTR_a, MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0} },
+    { MP_QSTR_b, MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0} },
+    { MP_QSTR_parent, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+    { MP_QSTR_up, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = GINPUT_TOGGLE_UP} },
+    { MP_QSTR_down, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = GINPUT_TOGGLE_DOWN} },
+};
+#define UGFX_LIST_MAKE_NEW_NUM_ARGS MP_ARRAY_SIZE(ugfx_list_make_new_args)
+
 STATIC mp_obj_t ugfx_list_make_new(const mp_obj_type_t *type, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
     // check arguments
-    mp_arg_check_num(n_args, n_kw, 4, 5, false);
+    mp_arg_val_t vals[UGFX_LIST_MAKE_NEW_NUM_ARGS];
+    mp_arg_parse_all_kw_array(n_args, n_kw, args, UGFX_LIST_MAKE_NEW_NUM_ARGS, ugfx_list_make_new_args, vals);
 
-	
-    //const char *text = mp_obj_str_get_str(args[4]);
-	int x = mp_obj_get_int(args[0]);
-	int y = mp_obj_get_int(args[1]);
-	int a = mp_obj_get_int(args[2]);
-	int b = mp_obj_get_int(args[3]);
-	
-	GHandle parent = NULL;
-	
     // create list object
     ugfx_list_obj_t *lst = m_new_obj(ugfx_list_obj_t);
     lst->base.type = &ugfx_list_type;
-	
-	
+
 	//setup list options
 	GWidgetInit	wi;
 
@@ -212,26 +215,29 @@ STATIC mp_obj_t ugfx_list_make_new(const mp_obj_type_t *type, mp_uint_t n_args, 
 	gwinWidgetClearInit(&wi);
 	wi.g.show = TRUE;
 
-	// Apply the list parameters	
-	wi.g.width = a;
-	wi.g.height = b;
-	wi.g.y = y;
-	wi.g.x = x;	
+	// Apply the list parameters
+	wi.g.width = vals[2].u_int;
+	wi.g.height = vals[3].u_int;
+	wi.g.y = vals[1].u_int;
+	wi.g.x = vals[0].u_int;
 	wi.text = 0;
-	
-	if (n_args > 4){
-		ugfx_container_obj_t *container = args[4];
-		if (MP_OBJ_IS_TYPE(args[4], &ugfx_container_type)) {
-			parent = container->ghContainer;
-			wi.customStyle = container->style;
-		}
+
+    // Apply parent
+    wi.g.parent = NULL;
+	if (MP_OBJ_IS_TYPE(vals[4].u_obj, &ugfx_container_type)) {
+        ugfx_container_obj_t *container = vals[4].u_obj;
+		wi.g.parent = container->ghContainer;
+		wi.customStyle = container->style;
 	}
-	wi.g.parent = parent;
 
 	// Create the actual list
 	lst->ghList = gwinListCreate(NULL, &wi, FALSE);   //FALSE - no multiselect
-	
+
 	//gwinListSetScroll(lst->ghList,scrollAlways);
+
+    // attach default inputs
+    gwinAttachToggle(lst->ghList, 1, vals[5].u_int);
+    gwinAttachToggle(lst->ghList, 0, vals[6].u_int); //mp_obj_get_int(args[6])
 
 	return lst;
 }
@@ -241,9 +247,9 @@ STATIC mp_obj_t ugfx_list_make_new(const mp_obj_type_t *type, mp_uint_t n_args, 
 /// frees up all resources
 STATIC mp_obj_t ugfx_list_destroy(mp_obj_t self_in) {
     ugfx_list_obj_t *self = self_in;
-    
+
 	gwinDestroy(self->ghList);
-	
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_list_destroy_obj, ugfx_list_destroy);
@@ -253,11 +259,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_list_destroy_obj, ugfx_list_destroy);
 ///
 STATIC mp_obj_t ugfx_list_attach_input(mp_obj_t self_in, mp_obj_t input, mp_obj_t function) {
     ugfx_list_obj_t *self = self_in;
-    int fun = mp_obj_get_int(function);	
+    int fun = mp_obj_get_int(function);
 	int i = mp_obj_get_int(input);
-	
+
 	gwinAttachToggle(self->ghList,fun,i);
-	
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(ugfx_list_attach_input_obj, ugfx_list_attach_input);
@@ -267,10 +273,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(ugfx_list_attach_input_obj, ugfx_list_attach_in
 ///
 STATIC mp_obj_t ugfx_list_detach_input(mp_obj_t self_in, mp_obj_t function) {
     ugfx_list_obj_t *self = self_in;
-    int fun = mp_obj_get_int(function);	
-	
+    int fun = mp_obj_get_int(function);
+
 	gwinDetachToggle(self->ghList,fun);
-	
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_list_detach_input_obj, ugfx_list_detach_input);
@@ -281,11 +287,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_list_detach_input_obj, ugfx_list_detach_in
 ///
 STATIC mp_obj_t ugfx_list_add_item(mp_obj_t self_in, mp_obj_t str) {
     ugfx_list_obj_t *self = self_in;
-	
+
 	const char *s = mp_obj_str_get_str(str);
-	
+
 	gwinListAddItem(self->ghList,s,TRUE);
-	
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_list_add_item_obj, ugfx_list_add_item);
@@ -294,8 +300,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_list_add_item_obj, ugfx_list_add_item);
 /// \method remove_item(index)
 ///
 STATIC mp_obj_t ugfx_list_remove_item(mp_obj_t self_in, mp_obj_t index) {
-    ugfx_list_obj_t *self = self_in;	
-	gwinListItemDelete(self->ghList, mp_obj_get_int(index));	
+    ugfx_list_obj_t *self = self_in;
+	gwinListItemDelete(self->ghList, mp_obj_get_int(index));
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_list_remove_item_obj, ugfx_list_remove_item);
@@ -304,8 +310,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_list_remove_item_obj, ugfx_list_remove_ite
 /// \method get_selected_text()
 ///
 STATIC mp_obj_t ugfx_list_get_selected_text(mp_obj_t self_in) {
-    ugfx_list_obj_t *self = self_in;	
-	const char* s = gwinListGetSelectedText(self->ghList);	
+    ugfx_list_obj_t *self = self_in;
+	const char* s = gwinListGetSelectedText(self->ghList);
     return mp_obj_new_str(s, strlen(s), TRUE);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_list_get_selected_obj, ugfx_list_get_selected_text);
@@ -314,7 +320,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_list_get_selected_obj, ugfx_list_get_selec
 /// \method get_selected_index()
 ///
 STATIC mp_obj_t ugfx_list_get_selected_index(mp_obj_t self_in) {
-    ugfx_list_obj_t *self = self_in;	
+    ugfx_list_obj_t *self = self_in;
     return mp_obj_new_int(gwinListGetSelected(self->ghList));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_list_get_selected_index_obj, ugfx_list_get_selected_index);
@@ -323,8 +329,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_list_get_selected_index_obj, ugfx_list_get
 /// \method set_selected_index()
 ///
 STATIC mp_obj_t ugfx_list_set_selected_index(mp_obj_t self_in, mp_obj_t index) {
-    ugfx_list_obj_t *self = self_in;	
-	gwinListSetSelected(self->ghList, mp_obj_get_int(index), TRUE);	
+    ugfx_list_obj_t *self = self_in;
+	gwinListSetSelected(self->ghList, mp_obj_get_int(index), TRUE);
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_list_set_selected_index_obj, ugfx_list_set_selected_index);
@@ -336,7 +342,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_list_set_selected_index_obj, ugfx_list_set
 /// \method count()
 ///
 STATIC mp_obj_t ugfx_list_count(mp_obj_t self_in) {
-    ugfx_list_obj_t *self = self_in;	
+    ugfx_list_obj_t *self = self_in;
     return mp_obj_new_int(gwinListItemCount(self->ghList));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_list_count_obj, ugfx_list_count);
@@ -384,9 +390,9 @@ const mp_obj_type_t ugfx_list_type = {
 /////////////////////////////////////////////////////
 
 typedef struct _ugfx_keyboard_t {
-    mp_obj_base_t base;	
+    mp_obj_base_t base;
 	GHandle ghKeyboard;
-	GListener	gl;	
+	GListener	gl;
 	mp_obj_t kb_callback;
 
 } ugfx_keyboard_obj_t;
@@ -399,20 +405,20 @@ STATIC mp_obj_t ugfx_keyboard_make_new(const mp_obj_type_t *type, mp_uint_t n_ar
     // check arguments
     mp_arg_check_num(n_args, n_kw, 4, 5, false);
 
-	
+
     //const char *text = mp_obj_str_get_str(args[4]);
 	int x = mp_obj_get_int(args[0]);
 	int y = mp_obj_get_int(args[1]);
 	int a = mp_obj_get_int(args[2]);
 	int b = mp_obj_get_int(args[3]);
-	
+
 	GHandle parent = NULL;
 
     // create keyboard object
     ugfx_keyboard_obj_t *kbd = m_new_obj(ugfx_keyboard_obj_t);
     kbd->base.type = &ugfx_keyboard_type;
-	
-	
+
+
 	//setup keyboard options
 	GWidgetInit	wi;
 
@@ -420,13 +426,13 @@ STATIC mp_obj_t ugfx_keyboard_make_new(const mp_obj_type_t *type, mp_uint_t n_ar
 	gwinWidgetClearInit(&wi);
 	wi.g.show = TRUE;
 
-	// Apply the keyboard parameters	
+	// Apply the keyboard parameters
 	wi.g.width = a;
 	wi.g.height = b;
 	wi.g.y = y;
-	wi.g.x = x;	
+	wi.g.x = x;
 	wi.text = 0; //text;
-	
+
 	if (n_args > 4){
 		ugfx_container_obj_t *container = args[4];
 		if (MP_OBJ_IS_TYPE(args[4], &ugfx_container_type)) {
@@ -438,7 +444,7 @@ STATIC mp_obj_t ugfx_keyboard_make_new(const mp_obj_type_t *type, mp_uint_t n_ar
 
 	// Create the actual keyboard
 	kbd->ghKeyboard = gwinKeyboardCreate(NULL, &wi);
-	
+
 	kbd->kb_callback = mp_const_none;
 
 
@@ -484,9 +490,9 @@ static void ugfx_keyboard_event(void *param, GEvent *pe) {
 ///
 STATIC mp_obj_t ugfx_set_keyboard_callback(mp_obj_t self_in, mp_obj_t callback) {
 	ugfx_keyboard_obj_t *self = self_in;
-	
+
 	if (callback == mp_const_none) {
-        self->kb_callback = mp_const_none;		
+        self->kb_callback = mp_const_none;
 		geventDetachSource(&(self->gl), gwinKeyboardGetEventSource(self->ghKeyboard));
     } else if (mp_obj_is_callable(callback)) {
         self->kb_callback = callback;
@@ -508,7 +514,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_set_keyboard_callback_obj, ugfx_set_keyboa
 ///
 STATIC mp_obj_t ugfx_clear_keyboard_callback(mp_obj_t self_in, mp_obj_t callback) {
 	ugfx_keyboard_obj_t *self = self_in;
-	
+
     self->kb_callback = mp_const_none;
 	geventDetachSource(&(self->gl), gwinKeyboardGetEventSource(self->ghKeyboard));
 
@@ -524,9 +530,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_clear_keyboard_callback_obj, ugfx_clear_ke
 /// frees up all resources
 STATIC mp_obj_t ugfx_keyboard_destroy(mp_obj_t self_in) {
     ugfx_keyboard_obj_t *self = self_in;
-    
+
 	gwinDestroy(self->ghKeyboard);
-	
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_keyboard_destroy_obj, ugfx_keyboard_destroy);
@@ -563,11 +569,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_keyboard_callback_obj, ugfx_keyboard_callb
 ///
 STATIC mp_obj_t ugfx_keyboard_attach_input(mp_obj_t self_in, mp_obj_t input, mp_obj_t function) {
     ugfx_keyboard_obj_t *self = self_in;
-    int fun = mp_obj_get_int(function);	
+    int fun = mp_obj_get_int(function);
 	int i = mp_obj_get_int(input);
-	
+
 	gwinAttachToggle(self->ghKeyboard,fun,i);
-	
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(ugfx_keyboard_attach_input_obj, ugfx_keyboard_attach_input);
@@ -580,10 +586,10 @@ STATIC const mp_map_elem_t ugfx_keyboard_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___del__), (mp_obj_t)&ugfx_keyboard_destroy_obj},
     { MP_OBJ_NEW_QSTR(MP_QSTR_attach_input), (mp_obj_t)&ugfx_keyboard_attach_input_obj },
     //{ MP_OBJ_NEW_QSTR(MP_QSTR_callback), (mp_obj_t)&ugfx_keyboard_callback_obj },
-	
+
 	{ MP_OBJ_NEW_QSTR(MP_QSTR_set_keyboard_callback), (mp_obj_t)&ugfx_set_keyboard_callback_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_clear_keyboard_callback), (mp_obj_t)&ugfx_clear_keyboard_callback_obj },
-  
+
 
 	//class constants
     //{ MP_OBJ_NEW_QSTR(MP_QSTR_RED),        MP_OBJ_NEW_SMALL_INT(Red) },
@@ -611,7 +617,7 @@ const mp_obj_type_t ugfx_keyboard_type = {
 
 typedef struct _ugfx_label_t {
     mp_obj_base_t base;
-	
+
 	GHandle ghLabel;
 
 } ugfx_label_obj_t;
@@ -624,20 +630,20 @@ STATIC mp_obj_t ugfx_label_make_new(const mp_obj_type_t *type, mp_uint_t n_args,
     // check arguments
     mp_arg_check_num(n_args, n_kw, 5, 6, false);
 
-	
+
     const char *text = mp_obj_str_get_str(args[4]);
 	int x = mp_obj_get_int(args[0]);
 	int y = mp_obj_get_int(args[1]);
 	int a = mp_obj_get_int(args[2]);
 	int b = mp_obj_get_int(args[3]);
-	
+
 	GHandle parent = NULL;
 
     // create label object
     ugfx_label_obj_t *btn = m_new_obj(ugfx_label_obj_t);
     btn->base.type = &ugfx_label_type;
-	
-	
+
+
 	//setup label options
 	GWidgetInit	wi;
 
@@ -645,13 +651,13 @@ STATIC mp_obj_t ugfx_label_make_new(const mp_obj_type_t *type, mp_uint_t n_args,
 	gwinWidgetClearInit(&wi);
 	wi.g.show = TRUE;
 
-	// Apply the label parameters	
+	// Apply the label parameters
 	wi.g.width = a;
 	wi.g.height = b;
 	wi.g.y = y;
-	wi.g.x = x;	
+	wi.g.x = x;
 	wi.text = text;
-	
+
 	if (n_args > 5){
 		ugfx_container_obj_t *container = args[5];
 		if (MP_OBJ_IS_TYPE(args[5], &ugfx_container_type)) {
@@ -674,9 +680,9 @@ STATIC mp_obj_t ugfx_label_make_new(const mp_obj_type_t *type, mp_uint_t n_args,
 STATIC mp_obj_t ugfx_label_set_text(mp_obj_t self_in, mp_obj_t str) {
     ugfx_label_obj_t *self = self_in;
     const char *s = mp_obj_str_get_str(str);
-	
+
 	gwinSetText(self->ghLabel, s, TRUE);
-	
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_label_set_text_obj, ugfx_label_set_text);
@@ -687,9 +693,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_label_set_text_obj, ugfx_label_set_text);
 /// frees up all resources
 STATIC mp_obj_t ugfx_label_destroy(mp_obj_t self_in) {
     ugfx_label_obj_t *self = self_in;
-    
+
 	gwinDestroy(self->ghLabel);
-	
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_label_destroy_obj, ugfx_label_destroy);
@@ -734,7 +740,7 @@ const mp_obj_type_t ugfx_label_type = {
 
 typedef struct _ugfx_checkbox_t {
     mp_obj_base_t base;
-	
+
 	GHandle ghCheckbox;
 
 } ugfx_checkbox_obj_t;
@@ -746,36 +752,36 @@ STATIC mp_obj_t ugfx_checkbox_make_new(const mp_obj_type_t *type, mp_uint_t n_ar
     // check arguments
     mp_arg_check_num(n_args, n_kw, 7, 7, false);
 
-	
+
     const char *text = mp_obj_str_get_str(args[5]);
 	int x = mp_obj_get_int(args[1]);
 	int y = mp_obj_get_int(args[2]);
 	int a = mp_obj_get_int(args[3]);
 	int b = mp_obj_get_int(args[4]);
-	
+
     // create button object
     ugfx_checkbox_obj_t *chk = m_new_obj(ugfx_checkbox_obj_t);
     chk->base.type = &ugfx_checkbox_type;
-	
-	
+
+
 	//setup button options
 	GWidgetInit	wi;
- 
+
 	// Apply some default values for GWIN
 	gwinWidgetClearInit(&wi);
 	wi.g.show = TRUE;
- 
-	// Apply the button parameters	
+
+	// Apply the button parameters
 	wi.g.width = a;
 	wi.g.height = b;
 	wi.g.y = y;
 	wi.g.x = x;
 	//wi.g.parent = ;
 	wi.text = text;
- 
+
 	// Create the actual button
 	chk->ghCheckbox = gwinCheckboxCreate(NULL, &wi);
-	
+
 
 	return chk;
 }
@@ -785,9 +791,9 @@ STATIC mp_obj_t ugfx_checkbox_make_new(const mp_obj_type_t *type, mp_uint_t n_ar
 /// clears up all associated memory
 STATIC mp_obj_t ugfx_check_destroy(mp_obj_t self_in) {
     ugfx_checkbox_obj_t *self = self_in;
-    
+
 	gwinDestroy(self->ghCheckbox);
-	
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_check_destroy_obj, ugfx_check_destroy);
@@ -798,11 +804,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(ugfx_check_destroy_obj, ugfx_check_destroy);
 /// attach a button to make button be pressable
 STATIC mp_obj_t ugfx_check_attach_input(mp_obj_t self_in, mp_obj_t input) {
     ugfx_checkbox_obj_t *self = self_in;
-	
+
 	int i = mp_obj_get_int(input);
-    
+
 	gwinAttachToggle(self->ghCheckbox,0,i);
-	
+
     return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(ugfx_check_attach_input_obj, ugfx_check_attach_input);


### PR DESCRIPTION
Creating a list on master:

``` py
options = ugfx.List(0,0,160,150)
options.attach_input(ugfx.JOY_UP, 1)
options.attach_input(ugfx.JOY_DOWN, 0)
```

Creating a list with this PR:

``` py
# simple list with inputs attached by default to up/down
options = ugfx.List(0,0,160,150)

# Up/Down mirrored
options = ugfx.List(0,0,160,150, up=ugfx.JOY_DOWN, down=ugfx.JOY_UP)

# List with parent
options = ugfx.List(0,0,160,150, parent=window)
```

Sorry for the messy diff, my editor deletes trailing spaces on save.
