### PR TITLE
Change default orientation

### DIFF
--- a/stmhal/gfxconf.h
+++ b/stmhal/gfxconf.h
@@ -138,7 +138,7 @@
 //#define GDISP_NEED_PIXMAP                            FALSE
 //    #define GDISP_NEED_PIXMAP_IMAGE                  FALSE
 
-#define GDISP_DEFAULT_ORIENTATION                    GDISP_ROTATE_LANDSCAPE    // If not defined the native hardware orientation is used.
+#define GDISP_DEFAULT_ORIENTATION                    GDISP_ROTATE_180    // If not defined the native hardware orientation is used.
 #define GDISP_LINEBUF_SIZE                           128
 #define GDISP_STARTUP_COLOR                          Black
 #define GDISP_NEED_STARTUP_LOGO                      FALSE


### PR DESCRIPTION
This makes the default orientation the one most likely to be used by apps (e.g. screen up = joystick up)
