### PR TITLE
Add ugfx.deinit()

### DIFF
--- a/stmhal/modugfx.c
+++ b/stmhal/modugfx.c
@@ -92,7 +92,13 @@ STATIC mp_obj_t ugfx_init(void) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(ugfx_init_obj, ugfx_init);
 
-
+/// \method deinit()
+///
+STATIC mp_obj_t ugfx_deinit(void) {
+    gfxDeinit();
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(ugfx_deinit_obj, ugfx_deinit);
 
 /// \method ball_demo()
 ///
@@ -870,6 +876,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ugfx_display_image_file_obj, 3, 3, ug
 STATIC const mp_map_elem_t ugfx_module_dict_table[] = {
     // instance methods
     { MP_OBJ_NEW_QSTR(MP_QSTR_init), (mp_obj_t)&ugfx_init_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_deinit), (mp_obj_t)&ugfx_deinit_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_text), (mp_obj_t)&ugfx_text_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_line), (mp_obj_t)&ugfx_line_obj },
 	{ MP_OBJ_NEW_QSTR(MP_QSTR_box), (mp_obj_t)&ugfx_box_obj },


### PR DESCRIPTION
There's probably a lot more we should do in that routine (like clear the screen, turn off backlight, destroy/free all ugfx objects)
