### PR TITLE
Change CC3100 SPI bus speed to 20MHz

### DIFF
--- a/stmhal/modnwcc3100.c
+++ b/stmhal/modnwcc3100.c
@@ -69,7 +69,7 @@ Fd_t spi_Open(char* pIfName, unsigned long flags)
 {
     mp_uint_t spi_clock, br_prescale;
     spi_clock = HAL_RCC_GetPCLK1Freq();
-    br_prescale = spi_clock / 40000000; //40MHz
+    br_prescale = spi_clock / 20000000; //20MHz
     if (br_prescale <= 2) { SPI_HANDLE->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2; }
     else if (br_prescale <= 4) { SPI_HANDLE->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_4; }
     else if (br_prescale <= 8) { SPI_HANDLE->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_8; }


### PR DESCRIPTION
The CC3100 datasheet says that the maximum supported SPI bus speed is
20MHz.  Some of the badges appear to work ok at 40MHz, but others show
flipped bits in downloaded files at this speed.
